### PR TITLE
Correções na estrutura

### DIFF
--- a/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
+++ b/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
@@ -1,6 +1,6 @@
 # *Setup* básico para desenvolver no VTEX IO
 
-Todo desenvolvimento no VTEX IO começa com o [**Toolbelt**](*link*), nossa CLI (Command Line Interface) que permite fazer login, desenvolver novas [apps](*link*) e gerenciar as já instaladas.
+Todo desenvolvimento no VTEX IO começa com o [**Toolbelt**](*https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-toolbelt*), nossa CLI (Command Line Interface) que permite fazer login, desenvolver novas aplicações e gerenciar as já instaladas.
 
 ## VTEX IO Toolbelt
 
@@ -16,7 +16,7 @@ $ yarn global add vtex
 
 ## Login
 
-Com a CLI do VTEX IO instalada, use o comando `vtex login para entrar na sua conta VTEX:
+Com a CLI do VTEX IO instalada, use o comando `vtex login` para entrar na sua conta VTEX:
 
 ```
 $ vtex login {ContaVTEX}
@@ -24,30 +24,30 @@ $ vtex login {ContaVTEX}
 
 Isso abrirá uma janela do seu navegador que solicitará suas credenciais.
 
-Quando já estiver *logado*, você pode usar o comando `vtex whoami` para descobrir qual conta e *workspace* estão sendo usados pelo terminal.
+Quando já estiver "logado", você pode usar o comando `vtex whoami` para descobrir qual conta e "workspace" estão sendo usados pelo terminal.
 
-![]("https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png"
+![vtex-whoami-exemplo](https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png)
   
-## Criando seu próprio *workspace*
+## Criando seu próprio "workspace"
 
-Ao usar o VTEX IO, toda interação com uma conta acontece em um [***workspace***](*link*).
+Ao usar o VTEX IO, toda interação com uma conta acontece em um [**"workspace"**](*https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-workspace*).
 
-Ao fazer *login* em uma loja, você está automaticamente no *workspace* master dela, ou seja, na versão disponível para o usuário final. Por isso, lembre-se que sempre que você quiser testar uma nova configuração, o seu próprio *workspace* de desenvolvimento deve ser criado usando o comando `vtex use`.
+Ao fazer "login" em uma loja, você está automaticamente no "workspace" master dela, ou seja, na versão disponível para o usuário final. Por isso, lembre-se que sempre que você quiser testar uma nova configuração, o seu próprio "workspace" de desenvolvimento deve ser criado usando o comando `vtex use`.
 
 ```
 $ vtex use {nomeexemplo}
 ```
 
-Isso muda o seu Toolbelt para um *workspace* chamado `nomeexemplo` e o cria se ele não existir.
+Isso muda o seu Toolbelt para um "workspace" chamado `nomeexemplo` e o cria se ele não existir.
 
 ![vtex-use-nomeexemplo](https://user-images.githubusercontent.com/52087100/61886135-7ffc0280-aed5-11e9-983f-4a76615d0574.png)
 
 >⚠️ *O `vtex use` faz com que todas as suas operações passem a ocorrer no `workspace` definido no comando. Isso significa que é possível alternar suas operações para master apenas executando no Toolbelt `vtex use master`, por exemplo.*
 
-Com o seu próprio *workspace* de desenvolvimento criado, você pode navegar na sua loja acessando:
+Com o seu próprio "workspace" de desenvolvimento criado, você pode navegar na sua loja acessando:
 
-`https://{{nomeexemplo}}-{{accountname}}.myvtex.com`
+`https://{nomeexemplo}-{accountname}.myvtex.com`
 
-Onde `workspace` é o *workspace* que você acabou de criar (como `nomeexemplo`) e `conta` é o nome da conta em que você está trabalhando.
+Onde `workspace` é o "workspace" que você acabou de criar - como `nomeexemplo` - e `conta` é o nome da conta em que você está trabalhando.
 
 Pronto! Agora você já pode desenvolver sua loja no VTEX IO.


### PR DESCRIPTION
Adicionando de fato a referência de um link para os termos Toolbet, e workspace.
Trocando da palavra apps para aplicações e retirada da marcação para link.
Corrigindo a marcação do comando "vtex login" na linha 19.
Corrigindo a referência para a imagem da linha 29 que não está sendo mostrada.
Trocando a marcação de termos em itálico para cercados com aspas (aqueles que representam estrangeirismos...).
Corrigindo a url mostrada na linha 49 (placeholder), para que cada variável tenha apenas um par de chaves ao seu redor.

**What problem is this solving?**

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**